### PR TITLE
BOL-11 - Don't immediately add track to history

### DIFF
--- a/boldaric/server.py
+++ b/boldaric/server.py
@@ -76,16 +76,16 @@ def get_next_songs(db, conn, pool, history, played, thumbs_downed):
     # Sort by similarity
     tracks.sort(key=lambda x: -x["similarity"])
 
+    # return all tracks that have subsonic info
+    tracks = list(filter(lambda t: "subsonic_id" in t["metadata"] and t["metadata"]["subsonic_id"] not in (None, ""), tracks))
+
     possible_tracks = [
         (x["metadata"]["artist"], x["metadata"]["title"], x["similarity"])
         for x in tracks
     ]
     logger.debug(f"Possible tracks {possible_tracks}")
 
-    # return all tracks that have subsonic info
-    tracks = filter(lambda t: "subsonic_id" in t["metadata"] and t["metadata"]["subsonic_id"] not in (None, ""), possible_tracks)
-    
-    return list(tracks)
+    return tracks
 
 @web.middleware
 async def auth_middleware(request, handler):
@@ -261,7 +261,7 @@ async def get_next_song_for_station(request):
                 "cover_url": cover_url,
             }
 
-        return web.json_response({"tracks": list(map(top_tracks, lambda t: make_response(t)))})
+        return web.json_response({"tracks": list(map(lambda t: make_response(t), top_tracks))})
     else:
         return web.json_response({"error": "Unable to find next song"}, status=400)
 


### PR DESCRIPTION
Resolved #11

- **- getting the next track for a station, now returns a list of items. Items are also slightly randomized, but weighted. - Don't immediately add any of those songs to the history, expect that the client will do that - Add a new api PUT /api/station/{station_id}/{song_id} to actually submit to history**
- **Return a map, not just a list**
- **Fixed typo**
- **Fixed function**
- **Fixed a bug**
- **Fix the fitler**
- **More fixes**
